### PR TITLE
PHP 7 error in string "cache-control"

### DIFF
--- a/sag/httpAdapters/SagCURLHTTPAdapter.php
+++ b/sag/httpAdapters/SagCURLHTTPAdapter.php
@@ -121,7 +121,7 @@ class SagCURLHTTPAdapter extends SagHTTPAdapter {
         else {
           $line = explode(':', $respHeaders[$i], 2);
           $line[0] = strtolower($line[0]);
-          $response->headers->$line[0] = ltrim($line[1]);
+          $response->headers->{$line[0]} = ltrim($line[1]);
 
           if($line[0] == 'set-cookie') {
             $response->cookies = $this->parseCookieString($line[1]);


### PR DESCRIPTION
The best way of put dynamic strings in a stdClass, is using "{ }" arround the key,
the variable 'cache-control' is broking the pipe without "{ }"